### PR TITLE
Update `How to start` (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Take a look at the components diagram that describes them and their interactions
 The easiest way is to use `docker-compose`:
 
 ```
-docker-compose up
+docker-compose up --build
 ```
 
 ## Contribution


### PR DESCRIPTION
Adding the flag `build` builds the images before attempting to run the services.

Not doing so creates this error:
`WARNING: Image for service todos-api was built because it did not already exist. To rebuild this image you must use docker-compose build or docker-compose up --build.`