### PR TITLE
Adds redis-queue to kubernetes setup

### DIFF
--- a/k8s/log-message-processor/deployment.yaml
+++ b/k8s/log-message-processor/deployment.yaml
@@ -3,30 +3,24 @@ kind: Deployment
 metadata:
   labels:
     app: microservice-app-example
-  name: todos-api
+  name: log-message-processor
 spec:
   replicas: 1
   template:
     metadata:
       labels:
         app: microservice-app-example
-        service: todos-api
+        service: log-message-processor
     spec:
       containers:
       - env:
-        - name: JWT_SECRET
-          value: myfancysecret
-        - name: TODO_API_PORT
-          value: "8082"
         - name: REDIS_HOST
           value: redis-queue
         - name: REDIS_PORT
           value: "6379"
         - name: REDIS_CHANNEL
           value: log_channel
-        image: todos-api
-        name: todos-api
-        ports:
-        - containerPort: 8082
+        image: log-message-processor
+        name: log-message-processor
         imagePullPolicy: Never
       restartPolicy: Always

--- a/k8s/redis-queue/deployment.yaml
+++ b/k8s/redis-queue/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: microservice-app-example
+  name: redis-queue
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: microservice-app-example
+        service: redis-queue
+    spec:
+      containers:
+      - env:
+        image: redis
+        name: redis-queue
+        ports:
+        - containerPort: 6379
+      restartPolicy: Always

--- a/k8s/redis-queue/service.yaml
+++ b/k8s/redis-queue/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: microservice-app-example
+  name: redis-queue
+spec:
+  ports:
+  - port: 6379
+  selector:
+    service: redis-queue


### PR DESCRIPTION
K8s setup lacked redis-queue and message-log-processor. Thus, it was failing with recent `todos-api` (because `todos-api` requires redis now).