### PR TITLE
python:3.6-alpine base image

### DIFF
--- a/log-message-processor/Dockerfile
+++ b/log-message-processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.6-alpine
 
 WORKDIR /usr/src/app
 RUN apk add --no-cache build-base


### PR DESCRIPTION
py_zipkin build fails on python:3-alpine base image